### PR TITLE
SvelteKit Routing Update (next.450+)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@sveltejs/adapter-static": "^1.0.0-next.42",
-        "@sveltejs/kit": "^1.0.0-next.471",
+        "@sveltejs/adapter-static": "next",
+        "@sveltejs/kit": "next",
         "mdsvex": "^0.10.6",
         "prettier": "^2.7.1",
         "prettier-plugin-svelte": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "format": "prettier --write --plugin-search-dir=. ."
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^1.0.0-next.42",
-    "@sveltejs/kit": "^1.0.0-next.471",
+    "@sveltejs/adapter-static": "next",
+    "@sveltejs/kit": "next",
     "mdsvex": "^0.10.6",
     "prettier": "^2.7.1",
     "prettier-plugin-svelte": "^2.7.0",


### PR DESCRIPTION
Upgrades to current SvelteKit (pre v1.0) routing (dir/+page.svelte, etc...), load and endpoints.

The routing upgrades change a few things including `$lib/utils/slugFromPath()`.

`export const prerender = true` caused errors on `/posts.json?limit=2` with the limit feature because it accessed URLParams so I removed it; I assume [?limit=1 on the live demo](https://sveltekit-mdsvex-blog.netlify.app/posts.json?limit=1) also doesn't work due to adapter-static limitations.

Thanks for sharing your example code!

Mark